### PR TITLE
Typo fixed, "respository".

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ ______           _   _    ___  ___            _
 Generate command:
 generate controller <name>
 generate service <name>
-generate respository <name>
+generate repository <name>
 
 ```
 
@@ -30,6 +30,6 @@ Example:
     $ cd folder_to_create_entity
     $ darthmaul generate controller <name>
     $ darthmaul generate service <name>
-    $ darthmaul generate respository <name>
+    $ darthmaul generate repository <name>
     $ darthmaul create-app <name>
 ```

--- a/menue/menue.go
+++ b/menue/menue.go
@@ -23,7 +23,7 @@ func (m menue) Show() {
 	fmt.Println("Generate command:")
 	fmt.Println("generate controller <name>")
 	fmt.Println("generate service <name>")
-	fmt.Println("generate respository <name>")
+	fmt.Println("generate repository <name>")
 	fmt.Println()
 	fmt.Println("Create command:")
 	fmt.Println("create-app <name>")


### PR DESCRIPTION
When i tried to generate a "respository" following the readme or the terminal help didn't work and show me an error... after some retries i tried with `darthmaul generate repository ...` and worked.
 
<img width="605" alt="Captura de Pantalla 2021-03-19 a la(s) 06 03 38" src="https://user-images.githubusercontent.com/18221356/111756773-5d241c00-8879-11eb-9c1c-8ec841820f9e.png">
